### PR TITLE
Reproduce and fix arrow-arith dependency conflict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,9 +1944,8 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+version = "0.4.39"
+source = "git+https://github.com/chronotope/chrono?tag=v0.4.39#8b863490d88ba098038392c8aa930012ffd0c439"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1954,7 +1953,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ chrono = { version = "0.4.38", features = ["serde"] }
 # Patch for Windows cross-compilation issue with crunchy
 [patch.crates-io]
 crunchy = { git = "https://github.com/nmathewson/crunchy", branch = "cross-compilation-fix" }
+chrono = { git = "https://github.com/chronotope/chrono", tag = "v0.4.39" }


### PR DESCRIPTION
Pin `chrono` dependency to `v0.4.39` to resolve a build error caused by conflicting `quarter` methods.

The `arrow-arith` crate encountered a compilation error (E0034) because `chrono` versions 0.4.40 and later introduced `Datelike::quarter`, which conflicted with `ChronoDateExt::quarter` already present in `arrow-arith`'s scope. Pinning `chrono` to `v0.4.39` (before `Datelike::quarter` was added) resolves this ambiguity.

---
<a href="https://cursor.com/background-agent?bcId=bc-f227c6d1-c51e-4457-a443-62bc2e8ef22d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f227c6d1-c51e-4457-a443-62bc2e8ef22d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

