### PR TITLE
Reproduce and fix arrow-arith dependency conflict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,9 +1944,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1954,7 +1954,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4630,7 +4630,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ uninlined_format_args = "allow"
 
 [workspace.dependencies]
 rmcp = { version = "0.5.0", features = ["schemars", "auth"] }
-chrono = { version = "0.4.38", features = ["serde"] }
+chrono = { version = ">=0.4.31, <0.4.40", features = ["serde"] }
 
 # Patch for Windows cross-compilation issue with crunchy
 [patch.crates-io]


### PR DESCRIPTION
Downgrades the `chrono` dependency to resolve a compilation error due to method ambiguity in `arrow-arith`.

The `arrow-arith` crate (v52.2.0) has a `quarter()` method in its `ChronoDateExt` trait. `Chrono` versions 0.4.40 and newer introduced their own `quarter()` method in the `Datelike` trait, leading to a "multiple applicable items in scope" (E0034) error. Constraining `chrono` to versions older than 0.4.40 resolves this conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-817ec369-882b-4bf7-9e83-f94a4c215d4b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-817ec369-882b-4bf7-9e83-f94a4c215d4b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

